### PR TITLE
fix: 이미지 올릴 때 경로 맞지 않는 문제 해결

### DIFF
--- a/src/main/java/kr/co/nogibackend/domain/github/dto/command/GithubCommitCommand.java
+++ b/src/main/java/kr/co/nogibackend/domain/github/dto/command/GithubCommitCommand.java
@@ -96,7 +96,7 @@ public record GithubCommitCommand(
 
 	private void addImageFiles(Map<String, String> fileMap) {
 		images.forEach(image ->
-			fileMap.put(image.getImageFilePath(newCategory), image.getImageFile())
+			fileMap.put(image.getImageFilePath(), image.getImageFile())
 		);
 	}
 
@@ -113,8 +113,8 @@ public record GithubCommitCommand(
 		String fileName,  // 이미지 파일명
 		String filePath   // 이미지 파일 경로
 	) {
-		public String getImageFilePath(String category) {
-			return category + "/" + filePath + "/" + fileName;
+		public String getImageFilePath() {
+			return filePath;
 		}
 
 		public String getImageFile() {

--- a/src/main/java/kr/co/nogibackend/domain/notion/NotionService.java
+++ b/src/main/java/kr/co/nogibackend/domain/notion/NotionService.java
@@ -249,6 +249,9 @@ public class NotionService {
 						String imagePath =
 							block.getImage().createMarkdownPath(page.getProperties().getCategory(), fileName);
 
+						// 마크 다운에 들어갈 이미지 경로 생성
+						String markdownImagePath = "./image/" + fileName;
+
 						// 캡션 생성
 						String caption = block.getImage().createCaption();
 
@@ -256,7 +259,7 @@ public class NotionService {
 							.append("![")
 							.append(caption)
 							.append("](")
-							.append(imagePath)
+							.append(markdownImagePath)
 							.append(")")
 							.append("\n");
 


### PR DESCRIPTION
## 📌 이미지가 저장되는 경로 수정
- NotionResult 에서 넘겨주는 filePath 그대로 사용해야하는데 category 도 앞에 추가해서 다르게 저장되었음
## 📌 markdown 의 이미지 경로 수정

-  상대 경로로 수정하였음.
-  절대 경로로 하는 방법은 userName + repositoryName + defaulotBranch 내용이 필요하여 코드 수정이 많이 필요하여 상대경로로 처리함

- 수정 전
![image](https://github.com/user-attachments/assets/fecdee44-0205-497d-a62c-4dfb55eb0039)

- 수정 후
![image](https://github.com/user-attachments/assets/e1bbc1d6-1e8f-492f-a687-390b0aaa6bd7)


